### PR TITLE
Modificações no fu-separator

### DIFF
--- a/snippets/flutter.json
+++ b/snippets/flutter.json
@@ -97,6 +97,11 @@
 		"body":"const SizedBox(height: $1),",
 		"description": "Create SizedBox separator"
 	},
+	"sized-box-horizontal-spacer": {
+		"prefix": "fu-separator-horizontal",
+		"body":"const SizedBox(width: $1),",
+		"description": "Create SizedBox horizontal separator"
+	},
 	"part.g.dart": {
 		"prefix": "fu-part",
 		"body": "part '$TM_FILENAME_BASE.g.dart';"

--- a/snippets/flutter.json
+++ b/snippets/flutter.json
@@ -94,11 +94,7 @@
 	},
 	"sized-box-spacer": {
 		"prefix": "fu-separator",
-		"body": [
-			"const SizedBox(",
-			"   height: $1,",
-			"),"
-		],
+		"body":"const SizedBox(height: $1),",
 		"description": "Create SizedBox separator"
 	},
 	"part.g.dart": {
@@ -133,6 +129,6 @@
 			"});"
 		]
 	}
-	
-	
+
+
 }


### PR DESCRIPTION
Como o objetivo é apenas incluir um espaço entre widgets, sugiro trazer o código do SizedBox em apenas uma linha já que o mesmo só terá um atributo utilizado.
Também inclui snippet para gerar separação horizontal.